### PR TITLE
Return to prior auto_refresh functionality

### DIFF
--- a/blinka_displayio_pygamedisplay.py
+++ b/blinka_displayio_pygamedisplay.py
@@ -32,8 +32,6 @@ __repo__ = "https://github.com/foamyguy/Foamyguy_CircuitPython_Blinka_Displayio_
 import time
 import threading
 from dataclasses import astuple
-from typing import Callable
-
 import displayio
 import pygame
 from PIL import Image

--- a/blinka_displayio_pygamedisplay.py
+++ b/blinka_displayio_pygamedisplay.py
@@ -32,6 +32,7 @@ __repo__ = "https://github.com/foamyguy/Foamyguy_CircuitPython_Blinka_Displayio_
 import time
 import threading
 from dataclasses import astuple
+from typing import Callable
 
 import displayio
 import pygame
@@ -154,8 +155,8 @@ class PyGameDisplay(displayio.Display):
     def event_loop(self, interval=None, on_time=None, on_event=None, events=None):
         """
         pygame event-loop. Has to be called by the main thread. This method
-        terminates in case of a QUIT-event. An optional callback `on_time` is
-        executed every `interval` seconds. Use this callback for
+        terminates in case of a QUIT-event. An optional callback on_time is
+        executed every interval seconds. Use this callback for
         application specific logic.
         """
         if events is None:

--- a/examples/blinka_displayio_pygamedisplay_anchor_test.py
+++ b/examples/blinka_displayio_pygamedisplay_anchor_test.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 Tim C, written for Adafruit Industries
+# SPDX-FileCopyrightText: 2020 Tim C
 #
 # SPDX-License-Identifier: Unlicense
 """
@@ -22,5 +22,6 @@ main_group.append(text_area)
 display.show(main_group)
 
 # text_area.y = 37
-while display.running:
-    pass
+while True:
+    if display.check_quit():
+        break

--- a/examples/blinka_displayio_pygamedisplay_button_example.py
+++ b/examples/blinka_displayio_pygamedisplay_button_example.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 Tim C, written for Adafruit Industries
+# SPDX-FileCopyrightText: 2020 Tim C
 #
 # SPDX-License-Identifier: Unlicense
 """
@@ -60,7 +60,7 @@ button.body.fill = 0x0000FF
 # pylint: disable=no-member
 
 # Must check display.running in the main loop!
-while display.running:
+while True:
     # get mouse up  events
     ev = pygame.event.get(eventtype=pygame.MOUSEBUTTONUP)
     # proceed events
@@ -83,3 +83,6 @@ while display.running:
         print(pos)
         if button.contains(pos):
             button.selected = True
+
+    if display.check_quit():
+        break

--- a/examples/blinka_displayio_pygamedisplay_imageload_bmp_test.py
+++ b/examples/blinka_displayio_pygamedisplay_imageload_bmp_test.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 Tim C, written for Adafruit Industries
+# SPDX-FileCopyrightText: 2020 Tim C
 #
 # SPDX-License-Identifier: Unlicense
 """
@@ -27,5 +27,6 @@ img_group.append(tile_grid)
 display.show(img_group)
 
 # Loop forever so you can enjoy your image
-while display.running:
-    pass
+while True:
+    if display.check_quit():
+        break

--- a/examples/blinka_displayio_pygamedisplay_partyparrot.py
+++ b/examples/blinka_displayio_pygamedisplay_partyparrot.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 Tim C, written for Adafruit Industries
+# SPDX-FileCopyrightText: 2020 Tim C
 #
 # SPDX-License-Identifier: Unlicense
 """
@@ -45,7 +45,7 @@ party = 0  #  time.monotonic() holder
 p = 0  #  index for tilegrid
 party_count = 0  #  count for animation cycles
 
-while display.running:
+while True:
     #  when a new tweet comes in...
     if parrot:
         #  every 0.1 seconds...
@@ -62,3 +62,6 @@ while display.running:
                 #  animation cycle count is updated
                 party_count += 1
                 print("party parrot", party_count)
+
+    if display.check_quit():
+        break

--- a/examples/blinka_displayio_pygamedisplay_progressbar_example.py
+++ b/examples/blinka_displayio_pygamedisplay_progressbar_example.py
@@ -37,7 +37,7 @@ progress_bar = ProgressBar(x, y, width, height, 1.0)
 splash.append(progress_bar)
 
 current_progress = 0.0
-while display.running:
+while True:
     # range end is exclusive so we need to use 1 bigger than max number that we want
     for current_progress in range(0, 101, 1):
         print("Progress: {}%".format(current_progress))
@@ -46,3 +46,6 @@ while display.running:
     time.sleep(0.3)
     progress_bar.progress = 0.0
     time.sleep(0.3)
+
+    if display.check_quit():
+        break

--- a/examples/blinka_displayio_pygamedisplay_pyportal_bitcoin.py
+++ b/examples/blinka_displayio_pygamedisplay_pyportal_bitcoin.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2017 Scott Shawcroft, written for Adafruit Industries
+# SPDX-FileCopyrightText: 2020 Tim C
 #
 # SPDX-License-Identifier: Unlicense
 """
@@ -55,7 +55,7 @@ pyportal = PyPortal(
 pyportal.preload_font(b"$012345789")  # preload numbers
 pyportal.preload_font((0x00A3, 0x20AC))  # preload gbp/euro symbol
 
-while display.running:
+while True:
     try:
         value = pyportal.fetch()
         print("Response is", value)
@@ -63,3 +63,6 @@ while display.running:
         print("Some error occured, retrying! -", e)
 
     time.sleep(3 * 60)  # wait 3 minutes
+
+    if display.check_quit():
+        break

--- a/examples/blinka_displayio_pygamedisplay_readme_example.py
+++ b/examples/blinka_displayio_pygamedisplay_readme_example.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 Tim C, written for Adafruit Industries
+# SPDX-FileCopyrightText: 2020 Tim C
 #
 # SPDX-License-Identifier: Unlicense
 """
@@ -18,6 +18,7 @@ color_palette[0] = 0x00FF00  # Bright Green
 bg_sprite = displayio.TileGrid(color_bitmap, pixel_shader=color_palette, x=0, y=0)
 splash.append(bg_sprite)
 
-# Must check display.running in the main loop!
-while display.running:
-    pass
+
+while True:
+    if display.check_quit():
+        break

--- a/examples/blinka_displayio_pygamedisplay_setup_only.py
+++ b/examples/blinka_displayio_pygamedisplay_setup_only.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 Tim C, written for Adafruit Industries
+# SPDX-FileCopyrightText: 2020 Tim C
 #
 # SPDX-License-Identifier: Unlicense
 """
@@ -17,5 +17,6 @@ main_group = displayio.Group()
 display.show(main_group)
 
 
-while display.running:
-    pass
+while True:
+    if display.check_quit():
+        break

--- a/examples/blinka_displayio_pygamedisplay_shapes.py
+++ b/examples/blinka_displayio_pygamedisplay_shapes.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 Tim C written for Adafruit Industries
+# SPDX-FileCopyrightText: 2020 Tim C
 #
 # SPDX-License-Identifier: Unlicense
 
@@ -79,5 +79,6 @@ roundrect.y += 270
 splash.append(roundrect)
 
 
-while display.running:
-    pass
+while True:
+    if display.check_quit():
+        break

--- a/examples/blinka_displayio_pygamedisplay_shapes_sparkline.py
+++ b/examples/blinka_displayio_pygamedisplay_shapes_sparkline.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 Kevin Matocha, Tim C, written for Adafruit Industries
+# SPDX-FileCopyrightText: 2020 Kevin Matocha, Tim C
 #
 # SPDX-License-Identifier: Unlicense
 """
@@ -131,7 +131,7 @@ for i in range(TOTAL_TICKS + 1):
 display.show(my_group)
 
 # Start the main loop
-while display.running:
+while True:
 
     # Turn off auto_refresh to prevent partial updates of the screen during updates
     # of the sparkline drawing
@@ -148,3 +148,6 @@ while display.running:
     # The display seems to be less jittery if a small sleep time is provided
     # You can adjust this to see if it has any effect
     time.sleep(0.01)
+
+    if display.check_quit():
+        break

--- a/examples/blinka_displayio_pygamedisplay_simpletest.py
+++ b/examples/blinka_displayio_pygamedisplay_simpletest.py
@@ -1,11 +1,14 @@
-# SPDX-FileCopyrightText: 2020 Tim C, written for Adafruit Industries
+# SPDX-FileCopyrightText: 2020 Tim C
 #
 # SPDX-License-Identifier: Unlicense
 """
 Make green and purple rectangles and a
 "Hello World" label.
 """
+import time
+
 import displayio
+import rainbowio
 import terminalio
 from adafruit_display_text import label
 from blinka_displayio_pygamedisplay import PyGameDisplay
@@ -43,5 +46,14 @@ text_area.anchored_position = (display.width // 2, display.height // 2)
 # text_group.append(text_area)  # Subgroup for text scaling
 splash.append(text_area)
 
-while display.running:
-    pass
+color_num = 0
+while True:
+    text_area.color = rainbowio.colorwheel(color_num)
+    color_num += 1
+    if color_num > 255:
+        color_num = 0
+    print(time.monotonic())
+    time.sleep(0.05)
+
+    if display.check_quit():
+        break

--- a/examples/display_text_bitmap_label_ascent_descent_test.py
+++ b/examples/display_text_bitmap_label_ascent_descent_test.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 Tim C, written for Adafruit Industries
+# SPDX-FileCopyrightText: 2020 Tim C
 #
 # SPDX-License-Identifier: Unlicense
 """
@@ -34,5 +34,6 @@ group.append(label)
 display.show(group)
 
 
-while display.running:
-    pass
+while True:
+    if display.check_quit():
+        break


### PR DESCRIPTION
Return the use of threading for auto_refresh functionality. Thank you @bablokb for getting that working!

New API option `event_loop()` can be used instead of a "main loop". 

`running` property has been replaced with `check_quit()` function. Call it in the main loop to check if user has pressed the X button on the window.  