### PR TITLE
Autodetect screen-size, add caption as parameter to constructor

### DIFF
--- a/blinka_displayio_pygamedisplay.py
+++ b/blinka_displayio_pygamedisplay.py
@@ -86,7 +86,7 @@ class PyGameDisplay(displayio.Display):
         super().__init__(None, _INIT_SEQUENCE, width=width, height=height, **kwargs)
 
     def _get_screen_size(self):
-        # pylint: disable=unused-argument
+        # pylint: disable=no-self-use
         """autodetect screen-size: returns tuple (width,height)"""
 
         # a bit clumsy: we need to init and deinit pygame for this

--- a/blinka_displayio_pygamedisplay.py
+++ b/blinka_displayio_pygamedisplay.py
@@ -59,6 +59,7 @@ class PyGameDisplay(displayio.Display):
         flags=0,
         **kwargs,
     ):
+        # pylint: disable=too-many-arguments
         """
         width  - width of the display. A value of zero maximizes the display
         height - height of the display. A value of zero maximizes the display

--- a/blinka_displayio_pygamedisplay.py
+++ b/blinka_displayio_pygamedisplay.py
@@ -86,6 +86,7 @@ class PyGameDisplay(displayio.Display):
         super().__init__(None, _INIT_SEQUENCE, width=width, height=height, **kwargs)
 
     def _get_screen_size(self):
+        # pylint: disable=unused-argument
         """autodetect screen-size: returns tuple (width,height)"""
 
         # a bit clumsy: we need to init and deinit pygame for this

--- a/blinka_displayio_pygamedisplay.py
+++ b/blinka_displayio_pygamedisplay.py
@@ -50,8 +50,18 @@ class PyGameDisplay(displayio.Display):
     hardware parameters.
     """
 
-    def __init__(self, icon=None, native_frames_per_second=60, flags=0, **kwargs):
+    def __init__(
+        self,
+        width=0,
+        height=0,
+        icon=None,
+        native_frames_per_second=60,
+        flags=0,
+        **kwargs,
+    ):
         """
+        width  - width of the display. A value of zero maximizes the display
+        height - height of the display. A value of zero maximizes the display
         icon - optional icon for the PyGame window
         native_frames_per_second - high values result in high cpu-load
         flags - pygame display-flags, e.g. pygame.FULLSCREEN or pygame.NOFRAME
@@ -68,7 +78,20 @@ class PyGameDisplay(displayio.Display):
         self._pygame_display_tevent = threading.Event()
         self._pygame_display_force_update = False
 
-        super().__init__(None, _INIT_SEQUENCE, **kwargs)
+        if (flags & pygame.FULLSCREEN) or width == 0 or height == 0:
+            width, height = self._get_screen_size()
+
+        super().__init__(None, _INIT_SEQUENCE, width=width, height=height, **kwargs)
+
+    def _get_screen_size(self):
+        """autodetect screen-size: returns tuple (width,height)"""
+
+        # a bit clumsy: we need to init and deinit pygame for this
+        pygame.init()  # pylint: disable=no-member
+        width = pygame.display.get_desktop_sizes()[0][0]
+        height = pygame.display.get_desktop_sizes()[0][1]
+        pygame.quit()
+        return width, height
 
     def _initialize(self, init_sequence):
         # pylint: disable=unused-argument

--- a/blinka_displayio_pygamedisplay.py
+++ b/blinka_displayio_pygamedisplay.py
@@ -26,7 +26,7 @@ Implementation Notes
 
 # imports
 
-__version__ = "0.0.0-auto.0"
+__version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/foamyguy/Foamyguy_CircuitPython_Blinka_Displayio_PyGameDisplay.git"
 
 import time

--- a/blinka_displayio_pygamedisplay.py
+++ b/blinka_displayio_pygamedisplay.py
@@ -55,22 +55,23 @@ class PyGameDisplay(displayio.Display):
         width=0,
         height=0,
         icon=None,
+        caption="Blinka Displayio PyGame",
         native_frames_per_second=60,
         flags=0,
         **kwargs,
     ):
         # pylint: disable=too-many-arguments
         """
-        width  - width of the display. A value of zero maximizes the display
-        height - height of the display. A value of zero maximizes the display
+        width  - width of the window. A value of zero maximizes the window
+        height - height of the window. A value of zero maximizes the window
         icon - optional icon for the PyGame window
+        caption - caption for the PyGame window
         native_frames_per_second - high values result in high cpu-load
         flags - pygame display-flags, e.g. pygame.FULLSCREEN or pygame.NOFRAME
         """
         self._native_frames_per_second = native_frames_per_second
-        self._icon = None
-        if icon:
-            self._icon = icon
+        self._icon = icon
+        self._caption = caption
         self._flags = flags
         self._subrectangles = []
 
@@ -112,7 +113,8 @@ class PyGameDisplay(displayio.Display):
             icon = pygame.image.load(self._icon)
             pygame.display.set_icon(icon)
 
-        pygame.display.set_caption("Blinka Displayio PyGame")
+        if self._caption:
+            pygame.display.set_caption(self._caption)
 
         self._pygame_screen = pygame.display.set_mode(
             size=(self._width, self._height), flags=self._flags


### PR DESCRIPTION
I managed to autodetect the screen-size before the displayio-core is initialized. So the pygame-display can now start in fullscreen with full resolution or alternatively maximized by passing width and/or height as zero.

I also added `caption` as an additional parameter to the constructor.

BTW: pip still installs the old, somewhat broken version.