### PR TITLE
Added no self use pylint extension

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -81,7 +81,7 @@ limit-inference-results=100
 
 # List of plugins (as comma separated values of python module names) to load,
 # usually to register additional checkers.
-load-plugins=
+load-plugins=pylint.extensions.no_self_use
 
 # Pickle collected data for later comparisons.
 persistent=yes


### PR DESCRIPTION
Not sure how this wasn't caught in the last PR, but here's the fix for the `pylint` issue.  Between removing the moved disable and enabling the extension I went with the latter because that was what the Adafruit libraries did, but either would work.  Let me know if you prefer the other option.